### PR TITLE
added new columns to original exams and labs

### DIFF
--- a/src/modules/exams/infra/typeorm/entities/OriginalExam.ts
+++ b/src/modules/exams/infra/typeorm/entities/OriginalExam.ts
@@ -44,6 +44,36 @@ class OriginalExam {
   @OneToMany(() => Price, price => price.original_exam_id)
   price: Price;
 
+  @Column()
+  description: string;
+
+  @Column()
+  preparation: string;
+
+  @Column()
+  sex: string;
+
+  @Column()
+  min_age: number;
+
+  @Column()
+  max_age: number;
+
+  @Column()
+  days_to_results: number;
+
+  @Column()
+  lab_min_price: number;
+
+  @Column()
+  lab_min_price_max_installments: number;
+
+  @Column()
+  lab_max_price: number;
+
+  @Column()
+  lab_max_price_max_installments: number;
+
   @CreateDateColumn()
   created_date: Date;
 

--- a/src/modules/labs/infra/typeorm/entities/Lab.ts
+++ b/src/modules/labs/infra/typeorm/entities/Lab.ts
@@ -57,6 +57,15 @@ class Lab {
   @Column()
   open_hour: string;
 
+  @Column()
+  how_to_get: string;
+
+  @Column()
+  technician_responsible: string;
+
+  @Column()
+  is_open: string;
+
   @OneToMany(() => OriginalExam, originalExam => originalExam.lab)
   original_exam: OriginalExam;
 

--- a/src/shared/infra/typeorm/migrations/1607621822932-AddDescriptionFieldsToOrigExamsAndLabs.ts
+++ b/src/shared/infra/typeorm/migrations/1607621822932-AddDescriptionFieldsToOrigExamsAndLabs.ts
@@ -1,0 +1,185 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export default class AddDescriptionFieldsToOrigExamsAndLabs1607621822932
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'labs',
+      new TableColumn({
+        name: 'how_to_get',
+        type: 'varchar',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'labs',
+      new TableColumn({
+        name: 'technician_responsible',
+        type: 'varchar',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'labs',
+      new TableColumn({
+        name: 'is_open',
+        type: 'boolean',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'original_exams',
+      new TableColumn({
+        name: 'description',
+        type: 'varchar',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'original_exams',
+      new TableColumn({
+        name: 'preparation',
+        type: 'varchar',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'original_exams',
+      new TableColumn({
+        name: 'sex',
+        type: 'varchar',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'original_exams',
+      new TableColumn({
+        name: 'min_age',
+        type: 'smallint',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'original_exams',
+      new TableColumn({
+        name: 'max_age',
+        type: 'smallint',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'original_exams',
+      new TableColumn({
+        name: 'days_to_results',
+        type: 'smallint',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'original_exams',
+      new TableColumn({
+        name: 'lab_min_price',
+        type: 'real',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'original_exams',
+      new TableColumn({
+        name: 'lab_min_price_max_installments',
+        type: 'real',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'original_exams',
+      new TableColumn({
+        name: 'lab_max_price',
+        type: 'real',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'original_exams',
+      new TableColumn({
+        name: 'lab_max_price_max_installments',
+        type: 'real',
+        isNullable: true,
+        isGenerated: false,
+        isUnique: false,
+        isPrimary: false,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn(
+      'original_exams',
+      'lab_max_price_max_installments',
+    );
+    await queryRunner.dropColumn('original_exams', 'lab_max_price');
+    await queryRunner.dropColumn(
+      'original_exams',
+      'lab_min_price_max_installments',
+    );
+    await queryRunner.dropColumn('original_exams', 'lab_min_price');
+    await queryRunner.dropColumn('original_exams', 'days_to_results');
+    await queryRunner.dropColumn('original_exams', 'max_age');
+    await queryRunner.dropColumn('original_exams', 'min_age');
+    await queryRunner.dropColumn('original_exams', 'sex');
+    await queryRunner.dropColumn('original_exams', 'preparation');
+    await queryRunner.dropColumn('original_exams', 'description');
+
+    await queryRunner.dropColumn('labs', 'is_open');
+    await queryRunner.dropColumn('labs', 'technician_responsible');
+    await queryRunner.dropColumn('labs', 'how_to_get');
+  }
+}


### PR DESCRIPTION
Created new columns based on what additional info labs provide us.

**1. Labs**:
- how_to_get
- technician_responsible
- is_open

**2. Original Exams**:
- description
- synonyms -- this one I did not implement yet because it is more tricky.. we should discuss how we could do it
- preparation
- sex
- min_age
- max_age
- days_to_results
- lab_min_price
- lab_min_price_max_installments
- lab_max_price
- lab_max_price_max_installments